### PR TITLE
Fee validation based on transaction type.

### DIFF
--- a/Tests/TransactionUnitTest.cpp
+++ b/Tests/TransactionUnitTest.cpp
@@ -36,13 +36,43 @@ public:
 	}
 	TEST_METHOD(setFee_Valid_Test) {
 		Transaction t = Transaction();
-		//TODO: Set alongside with amount and message payload to _calculate_ the fee.
 		Assert::IsTrue(t.setFee(2005000000));
 	}
 	TEST_METHOD(setFee_Invalid_Test) {
 		Transaction t = Transaction();
-		//TODO: Set alongside with amount and message payload to _calculate_ the fee.
 		Assert::IsFalse(t.setFee(-2005000000));
+	}
+	TEST_METHOD(isFeeValid_Transfer_Valid_Test) {
+		Transaction t = Transaction();
+		t.setAmount(45000);
+		t.setType(TRANSFER);
+		t.setFee(4);
+		Assert::IsTrue(t.isFeeValid(4));
+	}
+	TEST_METHOD(isFeeValid_Transfer_Invalid_Test) {
+		Transaction t = Transaction();
+		t.setAmount(45000);
+		t.setType(TRANSFER);
+		t.setFee(3);
+		Assert::IsFalse(t.isFeeValid(3));
+	}
+	TEST_METHOD(isFeeValid_MsgPayload_Valid_Test) {
+		Transaction t = Transaction();
+		t.setAmount(45000);
+		t.setMessageType(1);
+		t.setMessagePayload("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+		t.setType(TRANSFER);
+		t.setFee(7);
+		Assert::IsTrue(t.isFeeValid(7));
+	}
+	TEST_METHOD(isFeeValid_MsgPayload_Invalid_Test) {
+		Transaction t = Transaction();
+		t.setAmount(45000);
+		t.setMessageType(1);
+		t.setMessagePayload("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+		t.setType(TRANSFER);
+		t.setFee(7);
+		Assert::IsFalse(t.isFeeValid(7));
 	}
 	TEST_METHOD(setDeadline_Valid_Test) {
 		Transaction t = Transaction();

--- a/src/h/model/Transaction.h
+++ b/src/h/model/Transaction.h
@@ -10,6 +10,12 @@
 
 #define NEM_NEMESIS_EPOCH 1427587585
 
+#define TRANSFER 0x101
+#define TRANSFER_OF_IMPORTANCE 0x801
+#define AGGREGATE_MODIFICATION_TRANSACTION 0x1001
+#define MULTISIG_SIGNATURE_TRANSACTION 0x1002
+#define MULTISIG_TRANSACTION 0x1003
+
 using namespace std;
 
 /*
@@ -21,20 +27,23 @@ class Transaction : public Validatable
 	The number of seconds elapsed since the creation of the nemesis block. Future timestamps are not allowed.
 	Transaction validation detects future timestamps and returns an error in that case.
 	*/
-	time_t timestamp;
-	long long amount;
+	time_t timestamp = NULL;
+	long long amount = LLONG_MIN;
 	Signature signature;
-	int fee;
+	int fee = INT_MIN;
 	Key recipient;
-	int type;
-	time_t deadline;
+	int type = INT_MIN;
+	time_t deadline = NULL;
 	string messagePayload;
-	int messageType;
-	int version;
+	int messageType = INT_MIN;
+	int version = INT_MIN;
 	Key signer;
 	std::list<Mosaic> mosaics;
-	//TODO: Mosaic - Mosaic transaction?
-	//TODO: Sender - Transfer transaction
+
+public:
+	Transaction();
+	~Transaction();
+
 	bool isAmountValid(long long amount);
 	bool isTypeValid(int type);
 	bool isTimestampValid(time_t timestamp);
@@ -43,11 +52,6 @@ class Transaction : public Validatable
 	bool isMessagePayloadValid(string messagePayload);
 	bool isMessageTypeValid(int messageType);
 	bool isVersionValid(int version);
-	bool isMosaicsValid(std::list<Mosaic> mosaics);
-
-public:
-	Transaction();
-	~Transaction();
 
 	bool setTimestamp(double timestamp);
 	time_t getTimestamp();


### PR DESCRIPTION
Transaction parsing needs more attention though:
```
C:\Users\karm\PA193_test_parser_NEM (development-validation-trans-3)
λ Debug\PA193_test_parser_NEM.exe ExampleData\ValidBlock\block_with_mosaic_TA.json
Block is valid.
DONE

C:\Users\karm\PA193_test_parser_NEM (development-validation-trans-3)
λ Debug\PA193_test_parser_NEM.exe ExampleData\ValidBlock\block_with_mosaic_TA-1.json
Block is valid.
DONE

C:\Users\karm\PA193_test_parser_NEM (development-validation-trans-3)
λ Debug\PA193_test_parser_NEM.exe ExampleData\ValidBlock\block_with_mosaic_TA-2.json
Block is corrupted.
-----------------
Reason:
Invalid attribute count in transaction object
```